### PR TITLE
add a windows workaround for getting chrome version

### DIFF
--- a/R/version.r
+++ b/R/version.r
@@ -8,7 +8,20 @@
 #' @examples
 #' chrome_version()
 chrome_version <- function(quiet = FALSE, chrome_bin=Sys.getenv("HEADLESS_CHROME")) {
-  res <- processx::run(chrome_bin, "--version")
+  if(.Platform$OS.type == "windows") {
+    cmd <- "powershell"
+    powershell_cmd <- sprintf("(Get-Item -Path '%s').VersionInfo.ProductVersion", chrome_bin)
+    args <- c(
+      "-NoLogo",
+      "-NoProfile",
+      "-Command",
+      powershell_cmd
+    )
+  } else {
+    cmd <- chrome_bin
+    args <- "--version"
+  }
+  res <- processx::run(cmd, args)
   if (!quiet) message(res$stdout)
   return(invisible(trimws(res$stdout)))
 }


### PR DESCRIPTION
This follows a discussion and closes #6 by offering a workaround on windows based on a powershell command.

Some questions: 
* Is powershell always available on windows or should there be a fail safe (Trycatch ?)
* I don't know how to add some tests for OS specific stuff like that. An idea ? 



