### PR TITLE
Pdf file is now printed in the correct path

### DIFF
--- a/R/chrome-pdf.r
+++ b/R/chrome-pdf.r
@@ -94,7 +94,7 @@ chrome_dump_pdf <- function(url, path=NULL, overwrite=TRUE, prime=TRUE,
 
   }
 
-  file.copy("output.pdf", out_fil, overwrite = overwrite)
+  file.copy(file.path(dirname(chrome_bin), "output.pdf"), out_fil, overwrite = overwrite)
 
   return(invisible(out_fil))
 

--- a/R/chrome-pdf.r
+++ b/R/chrome-pdf.r
@@ -54,33 +54,6 @@ chrome_dump_pdf <- function(url, path=NULL, overwrite=TRUE, prime=TRUE,
   fil_ext <- tools::file_ext(fil_nam)
   fil_pre <- tools::file_path_sans_ext(fil_nam)
 
-  td <- tempdir()
-
-  setwd(td)
-
-  work_dir <- if (is.null(work_dir)) .get_app_dir() else work_dir
-
-  args <- c("--headless")
-  args <- c(args, "--disable-gpu")
-  args <- c(args, "--no-sandbox")
-  args <- c(args, "--allow-no-sandbox-job")
-  args <- c(args, sprintf("--user-data-dir=%s", work_dir))
-  args <- c(args, sprintf("--crash-dumps-dir=%s", work_dir))
-  args <- c(args, sprintf("--utility-allowed-dir=%s", work_dir))
-  args <- c(args, "--print-to-pdf", url)
-
-  vers <- chrome_version(quiet=TRUE)
-
-  .prime_url(url, as.numeric(prime), work_dir, chrome_bin)
-
-  processx::run(
-    command = chrome_bin,
-    args = args,
-    error_on_status = FALSE,
-    echo_cmd = FALSE,
-    echo = FALSE
-  ) -> res
-
   first_fil <- file.path(dir_nam, sprintf("%s.%s", fil_pre, fil_ext))
   out_fil <- first_fil
 
@@ -94,7 +67,32 @@ chrome_dump_pdf <- function(url, path=NULL, overwrite=TRUE, prime=TRUE,
 
   }
 
-  file.copy(file.path(dirname(chrome_bin), "output.pdf"), out_fil, overwrite = overwrite)
+  td <- tempdir()
+
+  setwd(td)
+
+  work_dir <- if (is.null(work_dir)) .get_app_dir() else work_dir
+
+  args <- c("--headless")
+  args <- c(args, "--disable-gpu")
+  args <- c(args, "--no-sandbox")
+  args <- c(args, "--allow-no-sandbox-job")
+  args <- c(args, sprintf("--user-data-dir=%s", work_dir))
+  args <- c(args, sprintf("--crash-dumps-dir=%s", work_dir))
+  args <- c(args, sprintf("--utility-allowed-dir=%s", work_dir))
+  args <- c(args, sprintf("--print-to-pdf=%s", out_fil), url)
+
+  vers <- chrome_version(quiet=TRUE)
+
+  .prime_url(url, as.numeric(prime), work_dir, chrome_bin)
+
+  processx::run(
+    command = chrome_bin,
+    args = args,
+    error_on_status = FALSE,
+    echo_cmd = FALSE,
+    echo = FALSE
+  ) -> res
 
   return(invisible(out_fil))
 

--- a/R/version.r
+++ b/R/version.r
@@ -8,7 +8,20 @@
 #' @examples
 #' chrome_version()
 chrome_version <- function(quiet = FALSE, chrome_bin=Sys.getenv("HEADLESS_CHROME")) {
-  res <- processx::run(chrome_bin, "--version")
+  if(.Platform$OS.type == "windows") {
+    cmd <- "powershell"
+    powershell_cmd <- sprintf("(Get-Item -Path '%s').VersionInfo.ProductVersion", chrome_bin)
+    args <- c(
+      "-NoLogo",
+      "-NoProfile",
+      "-Command",
+      powershell_cmd
+    )
+  } else {
+    cmd <- chrome_bin
+    args <- "--version"
+  }
+  res <- processx::run(cmd, args)
   if (!quiet) message(res$stdout)
   return(invisible(trimws(res$stdout)))
 }


### PR DESCRIPTION
this fixes #8. 

It follows PR #7 and currently contains its fix from `chrome_version`. It must be merged after. 

Proposal:

* pass the output path to `--print-to-pdf=<output>` instead of copying and renaming. 
* By default, chrome headless overwrite. I left you mechanism to add number to output filename if `overwrite=FALSE`

Should work on all system. It is working on windows now - I did not test on other system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/hrbrmstr/decapitated/9)
<!-- Reviewable:end -->
